### PR TITLE
Adding support for GCP keyless

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Truefoundry Google Cloud platform features module
 
 | Name | Type |
 |------|------|
+| [google_iam_workload_identity_pool.truefoundry_platform_feature_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.truefoundry_platform_feature_oidc_provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
 | [google_project_iam_custom_role.truefoundry_platform_feature_artifact_registry_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.truefoundry_platform_feature_cluster_integration_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.truefoundry_platform_feature_gcs_bucket_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
@@ -39,7 +41,7 @@ Truefoundry Google Cloud platform features module
 | [google_project_iam_member.truefoundry_platform_feature_secret_manager_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.truefoundry_platform_feature_token_creator_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.truefoundry_platform_feature_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_binding.truefoundry_platform_feature_flyte_propeller_service_account_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.truefoundry_platform_feature_service_account_workload_identity_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
 | [google_service_account_key.truefoundry_platform_feature_service_account_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
 | [random_string.random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [google_project.truefoundry_platform_feature_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
@@ -67,6 +69,10 @@ Truefoundry Google Cloud platform features module
 | <a name="input_service_account_enable_override"></a> [service\_account\_enable\_override](#input\_service\_account\_enable\_override) | Enable overriding name of service account. This will only be used if service\_account\_enabled is enabled. You need to pass service\_account\_override\_name to pass the service account name | `bool` | `false` | no |
 | <a name="input_service_account_enabled"></a> [service\_account\_enabled](#input\_service\_account\_enabled) | Enable service account feature in the platform | `bool` | `true` | no |
 | <a name="input_service_account_key_creation_enabled"></a> [service\_account\_key\_creation\_enabled](#input\_service\_account\_key\_creation\_enabled) | Enable service account key creation | `bool` | `true` | no |
+| <a name="input_service_account_keyless_enabled"></a> [service\_account\_keyless\_enabled](#input\_service\_account\_keyless\_enabled) | Enable keyless authentication using GCP Workload Identity Federation with OIDC. When enabled, an ADC credential config JSON is output via serviceaccount\_adc\_config. Can be enabled alongside service account key creation during migration | `bool` | `false` | no |
+| <a name="input_service_account_keyless_k8s_serviceaccount_name"></a> [service\_account\_keyless\_k8s\_serviceaccount\_name](#input\_service\_account\_keyless\_k8s\_serviceaccount\_name) | Kubernetes service account name that will impersonate the GCP service account. Required when service\_account\_keyless\_enabled is true | `string` | `"truefoundry"` | no |
+| <a name="input_service_account_keyless_namespace"></a> [service\_account\_keyless\_namespace](#input\_service\_account\_keyless\_namespace) | Kubernetes namespace of the service account that will impersonate the GCP service account. Required when service\_account\_keyless\_enabled is true | `string` | `"truefoundry"` | no |
+| <a name="input_service_account_keyless_oidc_issuer_url"></a> [service\_account\_keyless\_oidc\_issuer\_url](#input\_service\_account\_keyless\_oidc\_issuer\_url) | OIDC issuer URL of the Kubernetes cluster (e.g. https://oidc.eks.us-east-1.amazonaws.com/id/XXXX). Required when service\_account\_keyless\_enabled is true | `string` | `""` | no |
 | <a name="input_service_account_override_name"></a> [service\_account\_override\_name](#input\_service\_account\_override\_name) | Service account name. Only used if service\_account\_enable\_override is enabled | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
@@ -82,6 +88,7 @@ Truefoundry Google Cloud platform features module
 | <a name="output_docker_registry_enabled"></a> [docker\_registry\_enabled](#output\_docker\_registry\_enabled) | Docker registry feature enabled |
 | <a name="output_sa_auth_data"></a> [sa\_auth\_data](#output\_sa\_auth\_data) | Private key of the service account |
 | <a name="output_secret_manger_enabled"></a> [secret\_manger\_enabled](#output\_secret\_manger\_enabled) | Secret manager feature enabled |
+| <a name="output_serviceaccount_adc_config"></a> [serviceaccount\_adc\_config](#output\_serviceaccount\_adc\_config) | Application Default Credentials config JSON for keyless authentication via Workload Identity Federation |
 | <a name="output_serviceaccount_enabled"></a> [serviceaccount\_enabled](#output\_serviceaccount\_enabled) | Service account feature enabled |
 | <a name="output_serviceaccount_key"></a> [serviceaccount\_key](#output\_serviceaccount\_key) | Service account keys |
 | <a name="output_serviceaccount_key_creation_enabled"></a> [serviceaccount\_key\_creation\_enabled](#output\_serviceaccount\_key\_creation\_enabled) | Service account key creation feature enabled |

--- a/iam.tf
+++ b/iam.tf
@@ -233,7 +233,7 @@ resource "google_iam_workload_identity_pool_provider" "truefoundry_platform_feat
     "attribute.service_account_name" = "assertion['kubernetes.io']['serviceaccount']['name']"
   }
 
-  attribute_condition = var.service_account_keyless_k8s_serviceaccount_name == "*" ? "" : "google.subject == \"system:serviceaccount:${var.service_account_keyless_namespace}:${var.service_account_keyless_k8s_serviceaccount_name}\""
+  attribute_condition = var.service_account_keyless_k8s_serviceaccount_name == "*" ? null : "google.subject == \"system:serviceaccount:${var.service_account_keyless_namespace}:${var.service_account_keyless_k8s_serviceaccount_name}\""
 }
 
 // moved block

--- a/iam.tf
+++ b/iam.tf
@@ -186,14 +186,14 @@ resource "google_project_iam_member" "truefoundry_platform_feature_additional_ro
   member  = "serviceAccount:${local.serviceaccount_email}"
 }
 
-resource "google_service_account_iam_binding" "truefoundry_platform_feature_flyte_propeller_service_account_binding" {
+resource "google_service_account_iam_binding" "truefoundry_platform_feature_service_account_workload_identity_binding" {
   count              = var.service_account_enabled ? 1 : 0
   service_account_id = google_service_account.truefoundry_platform_feature_service_account[0].id
   role               = "roles/iam.workloadIdentityUser"
 
-  members = [
-    "serviceAccount:${var.project}.svc.id.goog[${var.flyte_propeller_serviceaccount_namespace}/${var.flyte_propeller_serviceaccount_name}]",
-  ]
+  members = compact([
+    "serviceAccount:${var.project}.svc.id.goog[${var.flyte_propeller_serviceaccount_namespace}/${var.flyte_propeller_serviceaccount_name}]", var.service_account_keyless_enabled ? local.service_account_iam_binding_principal : ""
+  ])
 }
 
 // service account key
@@ -202,8 +202,47 @@ resource "google_service_account_key" "truefoundry_platform_feature_service_acco
   service_account_id = google_service_account.truefoundry_platform_feature_service_account[0].id
 }
 
+################################################################################
+# Workload Identity Federation (keyless authentication)
+################################################################################
+
+// workload identity pool
+resource "google_iam_workload_identity_pool" "truefoundry_platform_feature_pool" {
+  count                     = var.service_account_enabled && var.service_account_keyless_enabled ? 1 : 0
+  project                   = var.project
+  workload_identity_pool_id = substr("${var.cluster_name}-tfy-pool", 0, 32)
+  display_name              = "${var.cluster_name}-tfy-pool"
+  description               = "Workload identity pool for TrueFoundry platform on ${var.cluster_name}"
+}
+
+// OIDC provider for the workload identity pool
+resource "google_iam_workload_identity_pool_provider" "truefoundry_platform_feature_oidc_provider" {
+  count                              = var.service_account_enabled && var.service_account_keyless_enabled ? 1 : 0
+  project                            = var.project
+  workload_identity_pool_id          = google_iam_workload_identity_pool.truefoundry_platform_feature_pool[0].workload_identity_pool_id
+  workload_identity_pool_provider_id = substr("${var.cluster_name}-tfy-oidc", 0, 32)
+  display_name                       = "${var.cluster_name}-tfy-oidc"
+
+  oidc {
+    issuer_uri = var.service_account_keyless_oidc_issuer_url
+  }
+
+  attribute_mapping = {
+    "google.subject"                 = "assertion.sub"
+    "attribute.namespace"            = "assertion['kubernetes.io']['namespace']"
+    "attribute.service_account_name" = "assertion['kubernetes.io']['serviceaccount']['name']"
+  }
+
+  attribute_condition = var.service_account_keyless_k8s_serviceaccount_name == "*" ? "" : "google.subject == \"system:serviceaccount:${var.service_account_keyless_namespace}:${var.service_account_keyless_k8s_serviceaccount_name}\""
+}
+
 // moved block
 moved {
   from = google_service_account.truefoundry_platform_feature_service_account
   to   = google_service_account.truefoundry_platform_feature_service_account[0]
+}
+
+moved {
+  from = google_service_account_iam_binding.truefoundry_platform_feature_flyte_propeller_service_account_binding[0]
+  to   = google_service_account_iam_binding.truefoundry_platform_feature_service_account_workload_identity_binding[0]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -11,4 +11,19 @@ locals {
   truefoundry_blob_storage_name  = var.blob_storage_enable_override ? var.blob_storage_override_name : "${local.truefoundry_platform_resources}-bucket"
   serviceaccount_name            = trimsuffix(substr("${local.truefoundry_platform_resources}-user", 0, 30), "-")
   serviceaccount_email           = var.service_account_enabled ? google_service_account.truefoundry_platform_feature_service_account[0].email : var.existing_service_account_email != "" ? var.existing_service_account_email : ""
+  serviceaccount_adc_config = var.service_account_enabled && var.service_account_keyless_enabled ? jsonencode({
+    universe_domain    = "googleapis.com"
+    type               = "external_account"
+    audience           = "//iam.googleapis.com/${google_iam_workload_identity_pool_provider.truefoundry_platform_feature_oidc_provider[0].name}"
+    subject_token_type = "urn:ietf:params:oauth:token-type:jwt"
+    token_url          = "https://sts.googleapis.com/v1/token"
+    credential_source = {
+      file = "/token"
+      format = {
+        type = "text"
+      }
+    }
+    service_account_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${local.serviceaccount_email}:generateAccessToken"
+  }) : ""
+  service_account_iam_binding_principal = var.service_account_keyless_k8s_serviceaccount_name == "*" ? "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.truefoundry_platform_feature_pool[0].name}/attribute.namespace/${var.service_account_keyless_namespace}" : "principal://iam.googleapis.com/${google_iam_workload_identity_pool.truefoundry_platform_feature_pool[0].name}/subject/system:serviceaccount:${var.service_account_keyless_namespace}:${var.service_account_keyless_k8s_serviceaccount_name}"
 }

--- a/output.tf
+++ b/output.tf
@@ -61,6 +61,12 @@ output "serviceaccount_key" {
   description = "Service account keys"
 }
 
+output "serviceaccount_adc_config" {
+  value       = local.serviceaccount_adc_config
+  sensitive   = true
+  description = "Application Default Credentials config JSON for keyless authentication via Workload Identity Federation"
+}
+
 ################################################################################
 # Secret manager
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -69,6 +69,30 @@ variable "service_account_additional_roles" {
   default     = []
 }
 
+variable "service_account_keyless_enabled" {
+  description = "Enable keyless authentication using GCP Workload Identity Federation with OIDC. When enabled, an ADC credential config JSON is output via serviceaccount_adc_config. Can be enabled alongside service account key creation during migration"
+  type        = bool
+  default     = false
+}
+
+variable "service_account_keyless_oidc_issuer_url" {
+  description = "OIDC issuer URL of the Kubernetes cluster (e.g. https://oidc.eks.us-east-1.amazonaws.com/id/XXXX). Required when service_account_keyless_enabled is true"
+  type        = string
+  default     = ""
+}
+
+variable "service_account_keyless_namespace" {
+  description = "Kubernetes namespace of the service account that will impersonate the GCP service account. Required when service_account_keyless_enabled is true"
+  type        = string
+  default     = "truefoundry"
+}
+
+variable "service_account_keyless_k8s_serviceaccount_name" {
+  description = "Kubernetes service account name that will impersonate the GCP service account. Required when service_account_keyless_enabled is true"
+  type        = string
+  default     = "truefoundry"
+}
+
 ################################################################################
 ## Flyte Propeller
 ################################################################################


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes IAM and federation trust (OIDC issuer, principal bindings, SA impersonation); misconfiguration could widen who can act as the platform service account.
> 
> **Overview**
> Adds **optional keyless GCP authentication** for the platform service account using **Workload Identity Federation (OIDC)**, controlled by `service_account_keyless_enabled` (default off). When enabled, Terraform creates a **WIF pool and OIDC provider** (cluster issuer URL, K8s namespace/SA, optional attribute condition) and extends the platform SA **`workloadIdentityUser`** binding with a WIF **principal** or **principalSet** (wildcard SA name supported).
> 
> The Flyte Propeller–only workload identity binding is **renamed and generalized**; GKE native `svc.id.goog[...]` membership for Flyte is preserved, with a **`moved` block** for state migration. A sensitive **`serviceaccount_adc_config`** output exposes an **external_account** ADC JSON (token file `/token`, SA impersonation) for workloads to use instead of JSON keys; key creation can stay on during migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ecdab3f21a0fa569c8c8e0457a9dc37c54317c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->